### PR TITLE
feat: implement team onboarding after signup

### DIFF
--- a/app/(app)/equipe/page.tsx
+++ b/app/(app)/equipe/page.tsx
@@ -1,11 +1,77 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import { Team } from '@/types/team';
+import { User } from '@/types/user';
+import { Button } from '@/components/ui/button';
+
 export default function EquipePage() {
+  const { user } = useAuth();
+  const [team, setTeam] = useState<Team | null>(null);
+
+  useEffect(() => {
+    if (user?.teamId) {
+      const teams = JSON.parse(localStorage.getItem('creator-teams') || '[]') as Team[];
+      const t = teams.find(team => team.id === user.teamId);
+      if (t) setTeam(t);
+    }
+  }, [user]);
+
+  const handleApprove = (email: string) => {
+    if (!team) return;
+    const teams = JSON.parse(localStorage.getItem('creator-teams') || '[]') as Team[];
+    const index = teams.findIndex(t => t.id === team.id);
+    if (index === -1) return;
+    teams[index].pending = teams[index].pending.filter(e => e !== email);
+    teams[index].members.push(email);
+    localStorage.setItem('creator-teams', JSON.stringify(teams));
+    setTeam(teams[index]);
+
+    const users = JSON.parse(localStorage.getItem('creator-users') || '[]') as User[];
+    const uIndex = users.findIndex(u => u.email === email);
+    if (uIndex > -1) {
+      users[uIndex].status = 'active';
+      localStorage.setItem('creator-users', JSON.stringify(users));
+    }
+  };
+
+  if (!team) {
+    return (
+      <div className="p-6">
+        <p className="text-muted-foreground">Nenhuma equipe encontrada.</p>
+      </div>
+    );
+  }
+
   return (
-    <div className="p-6">
-      <h1 className="text-3xl font-bold text-foreground mb-6">Equipe</h1>
+    <div className="p-6 space-y-6">
+      <h1 className="text-3xl font-bold text-foreground mb-6">{team.name}</h1>
+      {user?.role === 'admin' && (
+        <div className="bg-card rounded-lg p-6 shadow-sm">
+          <h2 className="text-xl font-semibold mb-4">Solicitações pendentes</h2>
+          {team.pending.length === 0 ? (
+            <p className="text-muted-foreground">Nenhuma solicitação.</p>
+          ) : (
+            <ul className="space-y-2">
+              {team.pending.map(email => (
+                <li key={email} className="flex justify-between items-center">
+                  <span>{email}</span>
+                  <Button size="sm" onClick={() => handleApprove(email)}>Aprovar</Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
       <div className="bg-card rounded-lg p-6 shadow-sm">
-        <p className="text-muted-foreground">
-          Página da equipe em desenvolvimento...
-        </p>
+        <h2 className="text-xl font-semibold mb-4">Membros</h2>
+        <ul className="space-y-1">
+          {team.members.map(email => (
+            <li key={email}>{email}</li>
+          ))}
+        </ul>
       </div>
     </div>
   );

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -49,9 +49,11 @@ export default function LoginPage() {
     setError('');
 
     setTimeout(() => {
-      const success = login({ email, password });
-      if (!success) {
+      const result = login({ email, password });
+      if (result === 'invalid') {
         setError('E-mail ou senha inválidos.');
+      } else if (result === 'pending') {
+        setError('Aguardando aprovação do administrador da equipe.');
       }
       setIsLoading(false);
     }, 1000);

--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -8,7 +8,7 @@ import { User } from '@/types/user';
 interface AuthContextType {
   isAuthenticated: boolean;
   user: User | null;
-  login: (data: Omit<User, 'name'>) => boolean;
+  login: (data: Omit<User, 'name'>) => 'success' | 'pending' | 'invalid';
   logout: () => void;
   updateUser: (updatedData: Partial<User>) => void; // <-- NOVA FUNÇÃO
   isLoading: boolean;
@@ -42,7 +42,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const login = (data: Omit<User, 'name'>): boolean => {
+  const login = (data: Omit<User, 'name'>): 'success' | 'pending' | 'invalid' => {
     try {
       const storedUsers = JSON.parse(localStorage.getItem('creator-users') || '[]') as User[];
       const foundUser = storedUsers.find(
@@ -50,6 +50,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       );
 
       if (foundUser) {
+        if (foundUser.status === 'pending') {
+          return 'pending';
+        }
         const userToAuth = { ...foundUser };
         delete userToAuth.password; // Não guardamos a senha no authUser
 
@@ -57,12 +60,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         localStorage.setItem('authToken', FAKE_TOKEN);
         localStorage.setItem('authUser', JSON.stringify(userToAuth));
         router.push('/home');
-        return true;
+        return 'success';
       }
-      return false;
+      return 'invalid';
     } catch (error) {
       console.error("Login failed", error);
-      return false;
+      return 'invalid';
     }
   };
 

--- a/types/team.ts
+++ b/types/team.ts
@@ -1,0 +1,8 @@
+export interface Team {
+  id: string;
+  name: string;
+  code: string;
+  admin: string; // admin email
+  members: string[];
+  pending: string[];
+}

--- a/types/user.ts
+++ b/types/user.ts
@@ -5,4 +5,7 @@ export interface User {
   phone?: string;
   state?: string;
   city?: string;
+  teamId?: string | null;
+  role?: 'admin' | 'member';
+  status?: 'active' | 'pending';
 }


### PR DESCRIPTION
## Summary
- add Team model and user team fields
- introduce post-signup dialogs to create or join a team
- block login until team request is approved
- add team page for admins to approve members

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: react/no-unescaped-entities and other warnings)


------
https://chatgpt.com/codex/tasks/task_e_6891edc0d2148326a1326b866ea58a5c