### PR TITLE
fix: isolate content approval history

### DIFF
--- a/app/(app)/content/result/page.tsx
+++ b/app/(app)/content/result/page.tsx
@@ -13,12 +13,12 @@ import type { Team } from '@/types/team';
 import { useAuth } from '@/hooks/useAuth';
 
 interface GeneratedContent {
+  id: string;
   imageUrl: string;
   title: string;
   body: string;
   hashtags: string[];
   revisions: number;
-  originalActionId?: string;
   brand?: string;
   theme?: string;
 }
@@ -82,13 +82,28 @@ export default function ResultPage() {
     if (!user?.teamId || !user?.email) return;
     try {
       const history = JSON.parse(localStorage.getItem('creator-action-history') || '[]');
-      const actionId = finalContent.originalActionId || `gen-${new Date().toISOString()}`;
-
+      const actionId = finalContent.id || `gen-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       const existingIndex = history.findIndex((a: any) => a.id === actionId);
+      const updatedResult = { ...finalContent, approved };
+
       if (existingIndex > -1) {
-        history[existingIndex].result = { ...finalContent, approved };
+        history[existingIndex].result = updatedResult;
         history[existingIndex].status = approved ? 'Aprovado' : 'Em revisão';
+      } else {
+        history.unshift({
+          id: actionId,
+          createdAt: new Date().toISOString(),
+          teamId: user.teamId,
+          userEmail: user.email,
+          type: 'Criar conteúdo',
+          brand: finalContent.brand || '',
+          theme: finalContent.theme || '',
+          details: {},
+          result: updatedResult,
+          status: approved ? 'Aprovado' : 'Em revisão'
+        });
       }
+
       localStorage.setItem('creator-action-history', JSON.stringify(history));
     } catch (e) {
       console.error("Erro ao salvar no histórico:", e);

--- a/components/content/content.tsx
+++ b/components/content/content.tsx
@@ -171,16 +171,16 @@ export default function Creator() {
 
       const data = await response.json();
 
-      const actionId = `gen-${Date.now()}`;
+      const actionId = `gen-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       const resultData = {
+        id: actionId,
         imageUrl: data.imageUrl,
         title: data.title,
         body: data.body,
         hashtags: data.hashtags,
         revisions: 0,
         brand: formData.brand,
-        theme: formData.theme,
-        originalActionId: actionId
+        theme: formData.theme
       };
 
       localStorage.setItem('generatedContent', JSON.stringify(resultData));

--- a/components/content/revisionForm.tsx
+++ b/components/content/revisionForm.tsx
@@ -10,6 +10,7 @@ import { toast } from 'sonner';
 
 interface RevisionFormProps {
   content: {
+    id: string;
     imageUrl: string;
     title: string;
     body: string;


### PR DESCRIPTION
## Summary
- ensure generated content receives unique id and keep it through revisions
- update history saving to update or insert by id without overwriting other posts
- propagate content id to revision form

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b61147f888326b73a0eca31858f0c