### PR TITLE
feat: add theme and persona API and migrate pages to prisma

### DIFF
--- a/app/api/brands/[id]/route.ts
+++ b/app/api/brands/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const data = await req.json();
+  try {
+    const brand = await prisma.brand.update({ where: { id: params.id }, data });
+    return NextResponse.json(brand);
+  } catch (error) {
+    console.error('Update brand error', error);
+    return NextResponse.json({ error: 'Failed to update brand' }, { status: 500 });
+  }
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  try {
+    await prisma.brand.delete({ where: { id: params.id } });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('Delete brand error', error);
+    return NextResponse.json({ error: 'Failed to delete brand' }, { status: 500 });
+  }
+}

--- a/app/api/brands/route.ts
+++ b/app/api/brands/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const teamId = searchParams.get('teamId');
+  if (!teamId) {
+    return NextResponse.json({ error: 'teamId is required' }, { status: 400 });
+  }
+  try {
+    const brands = await prisma.brand.findMany({ where: { teamId } });
+    return NextResponse.json(brands);
+  } catch (error) {
+    console.error('Fetch brands error', error);
+    return NextResponse.json({ error: 'Failed to fetch brands' }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  const data = await req.json();
+  try {
+    const brand = await prisma.brand.create({ data });
+    return NextResponse.json(brand);
+  } catch (error) {
+    console.error('Create brand error', error);
+    return NextResponse.json({ error: 'Failed to create brand' }, { status: 500 });
+  }
+}

--- a/app/api/personas/[id]/route.ts
+++ b/app/api/personas/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const data = await req.json();
+  try {
+    const persona = await prisma.persona.update({ where: { id: params.id }, data });
+    return NextResponse.json(persona);
+  } catch (error) {
+    console.error('Update persona error', error);
+    return NextResponse.json({ error: 'Failed to update persona' }, { status: 500 });
+  }
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  try {
+    await prisma.persona.delete({ where: { id: params.id } });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('Delete persona error', error);
+    return NextResponse.json({ error: 'Failed to delete persona' }, { status: 500 });
+  }
+}

--- a/app/api/personas/route.ts
+++ b/app/api/personas/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const teamId = searchParams.get('teamId');
+  if (!teamId) {
+    return NextResponse.json({ error: 'teamId is required' }, { status: 400 });
+  }
+  try {
+    const personas = await prisma.persona.findMany({ where: { teamId } });
+    return NextResponse.json(personas);
+  } catch (error) {
+    console.error('Fetch personas error', error);
+    return NextResponse.json({ error: 'Failed to fetch personas' }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  const data = await req.json();
+  try {
+    const persona = await prisma.persona.create({ data });
+    return NextResponse.json(persona);
+  } catch (error) {
+    console.error('Create persona error', error);
+    return NextResponse.json({ error: 'Failed to create persona' }, { status: 500 });
+  }
+}

--- a/app/api/themes/[id]/route.ts
+++ b/app/api/themes/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const data = await req.json();
+  try {
+    const theme = await prisma.strategicTheme.update({ where: { id: params.id }, data });
+    return NextResponse.json(theme);
+  } catch (error) {
+    console.error('Update theme error', error);
+    return NextResponse.json({ error: 'Failed to update theme' }, { status: 500 });
+  }
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  try {
+    await prisma.strategicTheme.delete({ where: { id: params.id } });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('Delete theme error', error);
+    return NextResponse.json({ error: 'Failed to delete theme' }, { status: 500 });
+  }
+}

--- a/app/api/themes/route.ts
+++ b/app/api/themes/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const teamId = searchParams.get('teamId');
+  if (!teamId) {
+    return NextResponse.json({ error: 'teamId is required' }, { status: 400 });
+  }
+  try {
+    const themes = await prisma.strategicTheme.findMany({ where: { teamId } });
+    return NextResponse.json(themes);
+  } catch (error) {
+    console.error('Fetch themes error', error);
+    return NextResponse.json({ error: 'Failed to fetch themes' }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  const data = await req.json();
+  try {
+    const theme = await prisma.strategicTheme.create({ data });
+    return NextResponse.json(theme);
+  } catch (error) {
+    console.error('Create theme error', error);
+    return NextResponse.json({ error: 'Failed to create theme' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add CRUD API endpoints for strategic themes and personas
- load, create, update and delete themes and personas through Prisma instead of local storage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react/no-unescaped-entities)*

------
https://chatgpt.com/codex/tasks/task_e_689c7433e8d08326905652c73a142cd6