### PR TITLE
Fix team retrieval from database and improve quote escaping

### DIFF
--- a/app/api/teams/[id]/route.ts
+++ b/app/api/teams/[id]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const team = await prisma.team.findUnique({ where: { id: params.id } });
+    if (!team) {
+      return NextResponse.json({ error: 'Team not found' }, { status: 404 });
+    }
+    return NextResponse.json(team);
+  } catch (error) {
+    console.error('Fetch team error', error);
+    return NextResponse.json({ error: 'Failed to fetch team' }, { status: 500 });
+  }
+}

--- a/components/marcas/brandDetails.tsx
+++ b/components/marcas/brandDetails.tsx
@@ -142,7 +142,7 @@ export default function BrandDetails({ brand, onEdit, onDelete }: BrandDetailsPr
             <AlertDialogHeader>
               <AlertDialogTitle>Você tem certeza?</AlertDialogTitle>
               <AlertDialogDescription>
-                Essa ação não pode ser desfeita. Isso irá deletar permanentemente a marca "{brand.name}".
+                Essa ação não pode ser desfeita. Isso irá deletar permanentemente a marca &quot;{brand.name}&quot;.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>

--- a/components/personas/personaDetails.tsx
+++ b/components/personas/personaDetails.tsx
@@ -94,7 +94,7 @@ export default function PersonaDetails({ persona, onEdit, onDelete, brands }: Pe
             <AlertDialogHeader>
               <AlertDialogTitle>Você tem certeza?</AlertDialogTitle>
               <AlertDialogDescription>
-                Essa ação não pode ser desfeita. Isso irá deletar permanentemente a persona "{persona.name}".
+                Essa ação não pode ser desfeita. Isso irá deletar permanentemente a persona &quot;{persona.name}&quot;.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>

--- a/components/temas/themeDetails.tsx
+++ b/components/temas/themeDetails.tsx
@@ -97,7 +97,7 @@ export default function ThemeDetails({ theme, onEdit, onDelete, brands }: ThemeD
             <AlertDialogHeader>
               <AlertDialogTitle>Você tem certeza?</AlertDialogTitle>
               <AlertDialogDescription>
-                Essa ação não pode ser desfeita. Isso irá deletar permanentemente o tema "{theme.title}".
+                Essa ação não pode ser desfeita. Isso irá deletar permanentemente o tema &quot;{theme.title}&quot;.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>


### PR DESCRIPTION
## Summary
- add API endpoint to fetch team data by id
- load team data into localStorage after login and on session restore
- escape quotes in delete confirmations to satisfy lint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c8d67d89c8326b3eece37b2e48258