### PR TITLE
feat: add env switching scripts

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,3 @@
+DATABASE_URL="postgresql://postgres.ezovprllxlhwctltvmwx:nTL9G89U3rUBFKvF@aws-1-sa-east-1.pooler.supabase.com:5432/postgres"
+NEXT_PUBLIC_SUPABASE_URL="https://ezovprllxlhwctltvmwx.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV6b3ZwcmxseGxod2N0bHR2bXd4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYxMjc0NDgsImV4cCI6MjA3MTcwMzQ0OH0.pA-QXFQLOEXwiT9i6WMRP4YPo5Pl7VyCGeoAkEhCRzU"

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+DATABASE_URL="postgresql://postgres.pynnaycajkflymnvcfcd:nTL9G89U3rUBFKvF@aws-0-sa-east-1.pooler.supabase.com:5432/postgres?pgbouncer=true&connection_limit=5&pool_timeout=20"
+NEXT_PUBLIC_SUPABASE_URL="https://pynnaycajkflymnvcfcd.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InB5bm5heWNhamtmbHltbnZjZmNkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTMzMDA1NjYsImV4cCI6MjA2ODg3NjU2Nn0.hi33HR92hqeTEkNkFo_QPw4sN81Y4f1toc9Lg4u6kMs"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
     "db:studio": "prisma studio",
-    "db:seed": "tsx prisma/seed.ts"
+    "db:seed": "tsx prisma/seed.ts",
+    "env:dev": "bash scripts/use-dev-env.sh",
+    "env:prod": "bash scripts/use-prod-env.sh"
   },
   "dependencies": {
     "@google-cloud/aiplatform": "^5.0.0",

--- a/scripts/use-dev-env.sh
+++ b/scripts/use-dev-env.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Copy development environment variables to .env
+cp .env.development .env
+echo "Switched to development environment"

--- a/scripts/use-prod-env.sh
+++ b/scripts/use-prod-env.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Copy production environment variables to .env
+cp .env.production .env
+echo "Switched to production environment"


### PR DESCRIPTION
## Summary
- add production and development environment files
- add scripts to switch between production and development env configs
- expose env switching via npm scripts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac63fe292483268a8bc7abe2986e9b