### PR TITLE
Integrar saída de vídeo da Runway e exibir no resultado

### DIFF
--- a/app/(app)/content/result/page.tsx
+++ b/app/(app)/content/result/page.tsx
@@ -27,6 +27,7 @@ import RevisionForm from '@/components/content/revisionForm';
 import type { Team } from '@/types/team';
 import { useAuth } from '@/hooks/useAuth';
 import { downloadImage } from '@/lib/download-utils';
+import { cn } from '@/lib/utils';
 
 // Interface para o conteúdo gerado baseada na Action do banco de dados
 interface GeneratedContent {
@@ -606,7 +607,12 @@ export default function ResultPage() {
 
         <main className="grid grid-cols-1 lg:grid-cols-2 gap-8">
           <div className="space-y-4">
-            <Card className="w-full aspect-square bg-muted/30 rounded-2xl overflow-hidden shadow-lg border-2 border-primary/10 relative">
+            <Card
+              className={cn(
+                'w-full bg-muted/30 rounded-2xl overflow-hidden shadow-lg border-2 border-primary/10 relative',
+                content.videoUrl ? 'aspect-video' : 'aspect-square'
+              )}
+            >
               {content.videoUrl ? (
                 <video
                   key={content.videoUrl}

--- a/app/api/generate-video/route.ts
+++ b/app/api/generate-video/route.ts
@@ -105,6 +105,25 @@ Responda somente com JSON válido contendo {"title","body","hashtags"}.
 
 const RUNWAY_API_BASE_URL = 'https://api.dev.runwayml.com';
 
+function extractVideoUrl(output: any): string {
+  if (!output) return '';
+  if (typeof output === 'string') return output;
+  if (output.videoUrl) return output.videoUrl;
+  if (output.url) return output.url;
+  if (output.video?.url) return output.video.url;
+  if (output.video?.uri) return output.video.uri;
+  if (output.video?.download_url) return output.video.download_url;
+  if (Array.isArray(output.videos) && output.videos.length > 0) {
+    const v = output.videos[0];
+    return v.url || v.uri || v.download_url || '';
+  }
+  if (Array.isArray(output.assets) && output.assets.length > 0) {
+    const a = output.assets[0];
+    return a.url || a.uri || a.download_url || '';
+  }
+  return '';
+}
+
 async function pollForVideoResult(taskId: string, runwayKey: string): Promise<any> {
   const pollEndpoint = `${RUNWAY_API_BASE_URL}/v1/tasks/${taskId}`;
 
@@ -400,8 +419,8 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Extrai a URL do vídeo
-    const videoUrl = videoOutput?.videoUrl || videoOutput?.url || '';
+    // Extrai a URL do vídeo do objeto de saída da Runway
+    const videoUrl = extractVideoUrl(videoOutput);
 
     if (!videoUrl) {
       console.error('[API generate-video] URL do vídeo não encontrada na resposta:', videoOutput);


### PR DESCRIPTION
## Summary
- extrai de forma robusta a URL do vídeo retornada pela Runway
- ajusta a página de resultado para exibir vídeos com proporção correta

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: PrismaClientConstructorValidationError: Invalid value undefined for datasource "db" provided to PrismaClient constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68b18650e4788326b9053ba850afaab3