### PR TITLE
fix: handle Runway API polling status

### DIFF
--- a/app/api/generate-video/route.ts
+++ b/app/api/generate-video/route.ts
@@ -151,14 +151,15 @@ async function pollForVideoResult(taskId: string, runwayKey: string): Promise<an
       }
 
       const taskData = await res.json();
+      const status = (taskData.status || '').toLowerCase();
       console.log(`[Runway Polling] Status atual: ${taskData.status}`);
 
-      if (taskData.status === 'succeeded') {
+      if (status === 'succeeded') {
         console.log(`[Runway Polling] Tarefa ${taskId} concluída com sucesso!`);
         return taskData.output;
       }
 
-      if (taskData.status === 'failed') {
+      if (status === 'failed') {
         console.error(`[Runway Polling] Tarefa ${taskId} falhou:`, taskData.error);
         throw new Error(`A geração do vídeo falhou. Motivo: ${taskData.error || 'Erro desconhecido'}`);
       }


### PR DESCRIPTION
## Summary
- normalize Runway API status check to handle uppercase values

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b18c854c4083268548a9877692a9b0