### PR TITLE
fix: add polling fallback for realtime hooks

### DIFF
--- a/hooks/useActionsRealtime.tsx
+++ b/hooks/useActionsRealtime.tsx
@@ -85,10 +85,14 @@ export function useActionsRealtime(teamId?: string, options: Options = {}) {
         }
       )
       .subscribe();
+    const interval = setInterval(() => {
+      fetchActions();
+    }, 15000);
     return () => {
       supabase.removeChannel(channel);
+      clearInterval(interval);
     };
-  }, [teamId]);
+  }, [teamId, fetchActions]);
 
   return { actions, loading, error, refetch: fetchActions };
 }

--- a/hooks/useBrandsRealtime.tsx
+++ b/hooks/useBrandsRealtime.tsx
@@ -45,8 +45,12 @@ export function useBrandsRealtime(teamId?: string) {
         fetchBrands
       )
       .subscribe();
+    const interval = setInterval(() => {
+      fetchBrands();
+    }, 15000);
     return () => {
       supabase.removeChannel(channel);
+      clearInterval(interval);
     };
   }, [teamId, fetchBrands]);
 

--- a/hooks/usePersonasRealtime.tsx
+++ b/hooks/usePersonasRealtime.tsx
@@ -45,8 +45,12 @@ export function usePersonasRealtime(teamId?: string) {
         fetchPersonas
       )
       .subscribe();
+    const interval = setInterval(() => {
+      fetchPersonas();
+    }, 15000);
     return () => {
       supabase.removeChannel(channel);
+      clearInterval(interval);
     };
   }, [teamId, fetchPersonas]);
 

--- a/hooks/useTeamsRealtime.tsx
+++ b/hooks/useTeamsRealtime.tsx
@@ -45,8 +45,12 @@ export function useTeamsRealtime(userId?: string) {
         fetchTeams
       )
       .subscribe();
+    const interval = setInterval(() => {
+      fetchTeams();
+    }, 15000);
     return () => {
       supabase.removeChannel(channel);
+      clearInterval(interval);
     };
   }, [userId, fetchTeams]);
 

--- a/hooks/useThemesRealtime.tsx
+++ b/hooks/useThemesRealtime.tsx
@@ -45,8 +45,12 @@ export function useThemesRealtime(teamId?: string) {
         fetchThemes
       )
       .subscribe();
+    const interval = setInterval(() => {
+      fetchThemes();
+    }, 15000);
     return () => {
       supabase.removeChannel(channel);
+      clearInterval(interval);
     };
   }, [teamId, fetchThemes]);
 


### PR DESCRIPTION
## Summary
- extend polling fallback to all realtime hooks to keep UI updates flowing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `timeout 60 npm run build` (fails: Invalid value undefined for datasource "db" provided to PrismaClient constructor)


------
https://chatgpt.com/codex/tasks/task_e_68b6dec7d15083269ecfcec11d8184a5