### PR TITLE
Integrate Stripe billing for plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # repositorio-teste-creator
+
+## Configuração do Stripe
+
+Para ativar a cobrança dos planos é necessário definir as variáveis de ambiente abaixo no `.env` do projeto:
+
+- `STRIPE_SECRET_KEY`: chave secreta da API da Stripe.
+- `STRIPE_WEBHOOK_SECRET`: segredo do webhook configurado no painel da Stripe.
+- `STRIPE_SUCCESS_URL` (opcional): URL completa de redirecionamento após um checkout bem sucedido. Caso não seja definida, será utilizado `NEXT_PUBLIC_BASE_URL/planos?success=true&session_id={CHECKOUT_SESSION_ID}`.
+- `STRIPE_CANCEL_URL` (opcional): URL de cancelamento do checkout. Por padrão utiliza `NEXT_PUBLIC_BASE_URL/planos?canceled=true`.
+- `STRIPE_PRICE_BASIC`, `STRIPE_PRICE_PRO`, `STRIPE_PRICE_ENTERPRISE`: IDs de preço (Price ID) dos planos cadastrados na Stripe utilizados pelo script de seed.
+
+Certifique-se também de atualizar os registros de planos existentes no banco de dados com os respectivos `stripePriceId` antes de habilitar a cobrança em produção.

--- a/app/api/plans/route.ts
+++ b/app/api/plans/route.ts
@@ -76,7 +76,8 @@ export async function POST(request: Request) {
         customContentSuggestions: validatedData.customContentSuggestions,
         contentPlans: validatedData.contentPlans,
         contentReviews: validatedData.contentReviews,
-        isActive: validatedData.isActive
+        isActive: validatedData.isActive,
+        stripePriceId: validatedData.stripePriceId ?? null
       }
     });
 

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getTokenPayload, isTokenExpired } from '@/lib/jwt';
+import { prisma } from '@/lib/prisma';
+import { createTeamSubscription } from '@/lib/subscription-utils';
+import { getStripeClient } from '@/lib/stripe';
+
+export const dynamic = 'force-dynamic';
+
+function getBaseUrl() {
+  return process.env.NEXT_PUBLIC_BASE_URL || process.env.APP_URL || 'http://localhost:3000';
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    const token = authHeader?.replace('Bearer ', '');
+
+    if (!token || isTokenExpired(token)) {
+      return NextResponse.json({ error: 'Token inválido ou expirado' }, { status: 401 });
+    }
+
+    const payload = getTokenPayload(token);
+    if (!payload?.userId) {
+      return NextResponse.json({ error: 'Token inválido' }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: payload.userId },
+      include: {
+        team: true,
+        adminTeams: true
+      }
+    });
+
+    if (!user || !user.teamId) {
+      return NextResponse.json({ error: 'Usuário não encontrado ou sem equipe' }, { status: 404 });
+    }
+
+    const isAdmin = user.role === 'ADMIN' || user.adminTeams.some(team => team.id === user.teamId);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Apenas administradores podem gerenciar assinaturas' }, { status: 403 });
+    }
+
+    const { planId } = await request.json();
+    if (!planId) {
+      return NextResponse.json({ error: 'planId é obrigatório' }, { status: 400 });
+    }
+
+    const plan = await prisma.plan.findUnique({ where: { id: planId } });
+    if (!plan || !plan.isActive) {
+      return NextResponse.json({ error: 'Plano não encontrado ou inativo' }, { status: 404 });
+    }
+
+    if (plan.price <= 0) {
+      const subscription = await createTeamSubscription(user.teamId, plan.name);
+
+      if (!subscription) {
+        return NextResponse.json({ error: 'Não foi possível ativar o plano gratuito' }, { status: 500 });
+      }
+
+      return NextResponse.json({
+        message: 'Plano gratuito ativado com sucesso',
+        subscriptionId: subscription.id
+      });
+    }
+
+    if (!plan.stripePriceId) {
+      return NextResponse.json({ error: 'Plano não está configurado para cobrança via Stripe' }, { status: 409 });
+    }
+
+    let stripe;
+    try {
+      stripe = getStripeClient();
+    } catch (stripeError) {
+      console.error('Stripe configuration error:', stripeError);
+      return NextResponse.json({ error: 'Configuração da Stripe ausente' }, { status: 500 });
+    }
+
+    const baseUrl = getBaseUrl();
+    const successUrlTemplate = process.env.STRIPE_SUCCESS_URL || `${baseUrl}/planos?success=true&session_id={CHECKOUT_SESSION_ID}`;
+    const cancelUrl = process.env.STRIPE_CANCEL_URL || `${baseUrl}/planos?canceled=true`;
+
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      payment_method_types: ['card'],
+      customer_email: user.email,
+      line_items: [
+        {
+          price: plan.stripePriceId,
+          quantity: 1
+        }
+      ],
+      success_url: successUrlTemplate,
+      cancel_url: cancelUrl,
+      metadata: {
+        teamId: user.teamId,
+        planId: plan.id,
+        planName: plan.name,
+        userId: user.id
+      },
+      subscription_data: {
+        metadata: {
+          teamId: user.teamId,
+          planId: plan.id,
+          planName: plan.name
+        }
+      }
+    });
+
+    if (!session.url) {
+      return NextResponse.json({ error: 'Não foi possível criar sessão de checkout' }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      url: session.url,
+      sessionId: session.id
+    });
+  } catch (error) {
+    console.error('Erro ao iniciar checkout da Stripe:', error);
+    return NextResponse.json({ error: 'Erro interno do servidor' }, { status: 500 });
+  }
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,0 +1,227 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { getStripeClient, getStripeWebhookSecret } from '@/lib/stripe';
+import { prisma } from '@/lib/prisma';
+import { createTeamSubscription, updateTeamPlan } from '@/lib/subscription-utils';
+import { SubscriptionStatus } from '@prisma/client';
+
+export const dynamic = 'force-dynamic';
+
+function mapStripeStatus(status: Stripe.Subscription.Status): SubscriptionStatus {
+  switch (status) {
+    case 'trialing':
+      return 'TRIAL';
+    case 'active':
+      return 'ACTIVE';
+    case 'canceled':
+      return 'CANCELED';
+    case 'incomplete':
+    case 'incomplete_expired':
+    case 'past_due':
+    case 'unpaid':
+      return 'PAYMENT_PENDING';
+    default:
+      return 'ACTIVE';
+  }
+}
+
+async function syncSubscriptionFromStripe(
+  stripeSubscription: Stripe.Subscription,
+  checkoutSessionId?: string
+) {
+  const metadata = stripeSubscription.metadata || {};
+  const teamId = metadata.teamId;
+  const planId = metadata.planId;
+
+  if (!teamId || !planId) {
+    console.warn('Assinatura Stripe sem metadata de teamId/planId.');
+    return;
+  }
+
+  const plan = await prisma.plan.findUnique({ where: { id: planId } });
+  if (!plan) {
+    console.error('Plano associado à assinatura não encontrado:', planId);
+    return;
+  }
+
+  const status = mapStripeStatus(stripeSubscription.status);
+  const isActive = status !== 'CANCELED' && status !== 'EXPIRED' && status !== 'PAYMENT_PENDING';
+  const currentPeriodEnd = stripeSubscription.current_period_end
+    ? new Date(stripeSubscription.current_period_end * 1000)
+    : null;
+  const trialEndDate = stripeSubscription.trial_end
+    ? new Date(stripeSubscription.trial_end * 1000)
+    : null;
+  const stripeCustomerId = typeof stripeSubscription.customer === 'string'
+    ? stripeSubscription.customer
+    : stripeSubscription.customer?.id || null;
+  const priceId = stripeSubscription.items.data[0]?.price?.id || plan.stripePriceId || null;
+
+  const existing = await prisma.subscription.findFirst({
+    where: {
+      OR: [
+        { stripeSubscriptionId: stripeSubscription.id },
+        checkoutSessionId ? { stripeCheckoutSessionId: checkoutSessionId } : undefined
+      ].filter(Boolean) as any
+    }
+  });
+
+  if (!existing) {
+    await createTeamSubscription(teamId, plan.name, {
+      status,
+      stripeSubscriptionId: stripeSubscription.id,
+      stripeCustomerId,
+      stripeCheckoutSessionId: checkoutSessionId,
+      stripePriceId: priceId,
+      currentPeriodEnd,
+      trialEndDate
+    });
+    return;
+  }
+
+  await prisma.subscription.update({
+    where: { id: existing.id },
+    data: {
+      status,
+      endDate: currentPeriodEnd ?? existing.endDate,
+      trialEndDate: trialEndDate ?? null,
+      isActive,
+      stripeSubscriptionId: stripeSubscription.id,
+      stripeCustomerId: stripeCustomerId || existing.stripeCustomerId || undefined,
+      stripeCheckoutSessionId: checkoutSessionId || existing.stripeCheckoutSessionId || undefined,
+      stripePriceId: priceId || existing.stripePriceId || undefined,
+      canceledAt: status === 'CANCELED' ? new Date() : existing.canceledAt
+    }
+  });
+
+  await prisma.team.update({
+    where: { id: teamId },
+    data: {
+      isTrialActive: status === 'TRIAL',
+      trialEndsAt: trialEndDate ?? null
+    }
+  });
+
+  if (isActive) {
+    await updateTeamPlan(teamId, plan.id);
+  } else if (status === 'CANCELED' || status === 'EXPIRED') {
+    const freePlan = await prisma.plan.findFirst({ where: { name: 'FREE' } });
+    if (freePlan) {
+      await updateTeamPlan(teamId, freePlan.id);
+    }
+  }
+}
+
+async function handleCheckoutSessionCompleted(stripe: Stripe, session: Stripe.Checkout.Session) {
+  const metadata = session.metadata || {};
+  const teamId = metadata.teamId;
+  const planId = metadata.planId;
+
+  if (!teamId || !planId) {
+    console.warn('Checkout concluído sem metadata de teamId/planId.');
+    return;
+  }
+
+  const existing = await prisma.subscription.findFirst({
+    where: {
+      OR: [
+        { stripeCheckoutSessionId: session.id },
+        typeof session.subscription === 'string'
+          ? { stripeSubscriptionId: session.subscription }
+          : undefined
+      ].filter(Boolean) as any
+    }
+  });
+
+  if (existing) {
+    return;
+  }
+
+  if (session.subscription) {
+    const subscriptionId = typeof session.subscription === 'string'
+      ? session.subscription
+      : session.subscription.id;
+
+    const stripeSubscription = await stripe.subscriptions.retrieve(subscriptionId);
+    await syncSubscriptionFromStripe(stripeSubscription, session.id);
+    return;
+  }
+
+  const plan = await prisma.plan.findUnique({ where: { id: planId } });
+  if (!plan) {
+    console.error('Plano associado ao checkout não encontrado:', planId);
+    return;
+  }
+
+  await createTeamSubscription(teamId, plan.name, {
+    status: 'ACTIVE',
+    stripeCheckoutSessionId: session.id,
+    stripeCustomerId: typeof session.customer === 'string'
+      ? session.customer
+      : session.customer?.id || null,
+    stripePriceId: plan.stripePriceId || null
+  });
+}
+
+export async function POST(request: NextRequest) {
+  let stripe: Stripe;
+  try {
+    stripe = getStripeClient();
+  } catch (error) {
+    console.error('Stripe client error:', error);
+    return NextResponse.json({ error: 'Stripe não configurado' }, { status: 500 });
+  }
+
+  let webhookSecret: string;
+  try {
+    webhookSecret = getStripeWebhookSecret();
+  } catch (error) {
+    console.error('Stripe webhook secret error:', error);
+    return NextResponse.json({ error: 'Webhook secret não configurado' }, { status: 500 });
+  }
+
+  const signature = request.headers.get('stripe-signature');
+  if (!signature) {
+    return NextResponse.json({ error: 'Assinatura não encontrada' }, { status: 400 });
+  }
+
+  let event: Stripe.Event;
+  const payload = await request.text();
+
+  try {
+    event = stripe.webhooks.constructEvent(payload, signature, webhookSecret);
+  } catch (err) {
+    console.error('Erro ao validar webhook Stripe:', err);
+    return NextResponse.json({ error: 'Payload inválido' }, { status: 400 });
+  }
+
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed':
+        await handleCheckoutSessionCompleted(stripe, event.data.object as Stripe.Checkout.Session);
+        break;
+      case 'customer.subscription.updated':
+      case 'customer.subscription.deleted':
+        await syncSubscriptionFromStripe(event.data.object as Stripe.Subscription);
+        break;
+      case 'invoice.payment_failed': {
+        const invoice = event.data.object as Stripe.Invoice;
+        if (invoice.subscription) {
+          const subscriptionId = typeof invoice.subscription === 'string'
+            ? invoice.subscription
+            : invoice.subscription.id;
+          const stripeSubscription = await stripe.subscriptions.retrieve(subscriptionId);
+          await syncSubscriptionFromStripe(stripeSubscription);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  } catch (error) {
+    console.error('Erro ao processar webhook Stripe:', error);
+    return NextResponse.json({ error: 'Erro ao processar evento' }, { status: 500 });
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/app/api/teams/create/route.ts
+++ b/app/api/teams/create/route.ts
@@ -50,7 +50,11 @@ export async function POST(req: Request) {
     });
 
     // Criar assinatura FREE com trial de 14 dias
-    await createTeamSubscription(team.id, 'FREE');
+    const subscription = await createTeamSubscription(team.id, 'FREE');
+
+    if (!subscription) {
+      return NextResponse.json({ error: 'Falha ao configurar assinatura inicial' }, { status: 500 });
+    }
 
     return NextResponse.json(team);
   } catch (error) {

--- a/app/api/teams/subscribe/route.ts
+++ b/app/api/teams/subscribe/route.ts
@@ -55,15 +55,16 @@ export async function POST(request: NextRequest) {
     }
 
     // Criar nova assinatura
-    const success = await createTeamSubscription(user.teamId, planName);
+    const subscription = await createTeamSubscription(user.teamId, planName);
 
-    if (!success) {
+    if (!subscription) {
       return NextResponse.json({ error: 'Erro ao criar assinatura' }, { status: 500 });
     }
 
-    return NextResponse.json({ 
+    return NextResponse.json({
       message: 'Assinatura criada com sucesso',
-      planName: plan.displayName
+      planName: plan.displayName,
+      subscriptionId: subscription.id
     });
 
   } catch (error) {

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,0 +1,29 @@
+import Stripe from 'stripe';
+
+const apiVersion: Stripe.LatestApiVersion = '2024-06-20';
+
+let stripeClient: Stripe | null = null;
+
+export function getStripeClient(): Stripe {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+
+  if (!secretKey) {
+    throw new Error('STRIPE_SECRET_KEY não está configurada.');
+  }
+
+  if (!stripeClient) {
+    stripeClient = new Stripe(secretKey, { apiVersion });
+  }
+
+  return stripeClient;
+}
+
+export function getStripeWebhookSecret(): string {
+  const secret = process.env.STRIPE_WEBHOOK_SECRET;
+
+  if (!secret) {
+    throw new Error('STRIPE_WEBHOOK_SECRET não está configurada.');
+  }
+
+  return secret;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "replicate": "^1.0.1",
         "resend": "^6.0.1",
         "sonner": "^1.7.4",
+        "stripe": "^18.5.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.3",
@@ -4839,7 +4840,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -9002,7 +9002,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10626,7 +10625,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10646,7 +10644,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10663,7 +10660,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -10682,7 +10678,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -11047,6 +11042,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "18.5.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.5.0.tgz",
+      "integrity": "sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/stripe/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strnum": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "replicate": "^1.0.1",
     "resend": "^6.0.1",
     "sonner": "^1.7.4",
+    "stripe": "^18.5.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -210,6 +210,7 @@ model Plan {
   contentPlans             Int
   contentReviews           Int
   isActive                 Boolean        @default(true)
+  stripePriceId            String?        @unique
   createdAt                DateTime       @default(now())
   updatedAt                DateTime       @updatedAt
   teamsUsingPlan           Team[]         @relation("TeamCurrentPlan")
@@ -226,6 +227,10 @@ model Subscription {
   trialEndDate DateTime?
   isActive     Boolean            @default(true)
   canceledAt   DateTime?
+  stripeSubscriptionId String? @unique
+  stripeCustomerId     String?
+  stripeCheckoutSessionId String? @unique
+  stripePriceId        String?
   createdAt    DateTime           @default(now())
   updatedAt    DateTime           @updatedAt
   plan         Plan               @relation(fields: [planId], references: [id])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -6,6 +6,12 @@ async function main() {
   console.log('🌱 Iniciando seed dos planos...')
 
   // Criar planos se não existirem
+  const {
+    STRIPE_PRICE_BASIC,
+    STRIPE_PRICE_PRO,
+    STRIPE_PRICE_ENTERPRISE,
+  } = process.env
+
   const plans = [
     {
       name: 'FREE',
@@ -20,7 +26,8 @@ async function main() {
       customContentSuggestions: 15,
       contentPlans: 5,
       contentReviews: 10,
-      isActive: true
+      isActive: true,
+      stripePriceId: null
     },
     {
       name: 'BASIC',
@@ -35,7 +42,8 @@ async function main() {
       customContentSuggestions: 20,
       contentPlans: 7,
       contentReviews: 15,
-      isActive: true
+      isActive: true,
+      stripePriceId: STRIPE_PRICE_BASIC || null
     },
     {
       name: 'PRO',
@@ -50,7 +58,8 @@ async function main() {
       customContentSuggestions: 30,
       contentPlans: 10,
       contentReviews: 25,
-      isActive: true
+      isActive: true,
+      stripePriceId: STRIPE_PRICE_PRO || null
     },
     {
       name: 'ENTERPRISE',
@@ -65,7 +74,8 @@ async function main() {
       customContentSuggestions: 200,
       contentPlans: 100,
       contentReviews: 200,
-      isActive: true
+      isActive: true,
+      stripePriceId: STRIPE_PRICE_ENTERPRISE || null
     }
   ]
 

--- a/types/team.ts
+++ b/types/team.ts
@@ -13,6 +13,7 @@ export interface Plan {
   contentPlans: number;
   contentReviews: number;
   isActive: boolean;
+  stripePriceId?: string | null;
 }
 
 export interface Team {


### PR DESCRIPTION
## Summary
- add Stripe checkout session creation API and webhook handler to activate or update team subscriptions
- extend plan validations, schema, and seeding data to store Stripe price identifiers and capture Stripe metadata on subscriptions
- refresh the plans page to call the new checkout API, handle success/cancel states, and document required Stripe environment variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d29b7b83188326a92a45453b78c5a5